### PR TITLE
Update name of CMS DataProvider to avoid conflicts

### DIFF
--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -17,7 +17,7 @@
     <type name="Magento\Search\Model\Autocomplete">
         <arguments>
             <argument name="dataProviders" xsi:type="array">
-                <item name="30" xsi:type="object">Smile\ElasticsuiteCms\Model\Autocomplete\Page\DataProvider</item>
+                <item name="50" xsi:type="object">Smile\ElasticsuiteCms\Model\Autocomplete\Page\DataProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
With standard Elasticsuite modules, there is a conflict with product_attribute DataProvider, each have name:30, so this commit set CMS DataProvider name to 50
  