### PR TITLE
Change field declaration from string to text in order to ElasticSearc…

### DIFF
--- a/etc/elasticsuite_indices.xml
+++ b/etc/elasticsuite_indices.xml
@@ -24,23 +24,23 @@
                 <!-- Static fields handled by the base indexer (not datasource) -->
                 <field name="page_id" type="integer" />
                 <field name="store_id" type="integer" />
-                <field name="title" type="string">
+                <field name="title" type="text">
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>
-                <field name="content_heading" type="string">
+                <field name="content_heading" type="text">
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>
-                <field name="content" type="string">
+                <field name="content" type="text">
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>
-                <field name="meta_keywords" type="string">
+                <field name="meta_keywords" type="text">
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>
-                <field name="meta_description" type="string">
+                <field name="meta_description" type="text">
                     <isSearchable>1</isSearchable>
                     <isUsedInSpellcheck>1</isUsedInSpellcheck>
                 </field>


### PR DESCRIPTION
Solve problem related to:

```
Elasticsuite Cms Page Indexing indexer process unknown error:
{"error":{"root_cause":[{"type":"mapper_parsing_exception","reason":"No handler for type [string] declared on field [content_heading]"}],"type":"mapper_parsing_exception","reason":"No handler for type [string] declared on field [content_heading]"},"status":400}
```