### PR TITLE
Miss translate attribute for item

### DIFF
--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -20,7 +20,7 @@
             <arguments>
                 <argument name="rendererList" xsi:type="array">
                     <item name="cms_page" xsi:type="array">
-                        <item name="title" xsi:type="string">Cms page</item>
+                        <item name="title" xsi:type="string" translate="true">Cms page</item>
                         <item name="template" xsi:type="string">Smile_ElasticsuiteCms/autocomplete/cms</item>
                     </item>
                 </argument>


### PR DESCRIPTION
Good afternoon,

In trying to translate "Cms page" label with a custom string, I have noticed it did not take it in account.

This fix solved the problem.

Ilan PARMENTIER