### PR TITLE
Proper title and breadcrumbs

### DIFF
--- a/Block/Page/Result.php
+++ b/Block/Page/Result.php
@@ -66,6 +66,34 @@ class Result extends \Magento\Framework\View\Element\Template
     }
 
     /**
+     * Prepare layout
+     *
+     * @return $this
+     */
+    protected function _prepareLayout()
+    {
+        $title = $this->getSearchQueryText();
+        $this->pageConfig->getTitle()->set($title);
+        // add Home breadcrumb
+        $breadcrumbs = $this->getLayout()->getBlock('breadcrumbs');
+        if ($breadcrumbs) {
+            $breadcrumbs->addCrumb(
+                'home',
+                [
+                    'label' => __('Home'),
+                    'title' => __('Go to Home Page'),
+                    'link' => $this->_storeManager->getStore()->getBaseUrl()
+                ]
+            )->addCrumb(
+                'search',
+                ['label' => $title, 'title' => $title]
+            );
+        }
+
+        return parent::_prepareLayout();
+    }
+
+    /**
      * Returns cms page collection.
      *
      * @return \Smile\ElasticsuiteCms\Model\ResourceModel\Page\Fulltext\Collection
@@ -115,6 +143,16 @@ class Result extends \Magento\Framework\View\Element\Template
     public function getPageUrl($pageId)
     {
         return $this->cmsPage->getPageUrl($pageId);
+    }
+
+    /**
+     * Get search query text
+     *
+     * @return \Magento\Framework\Phrase
+     */
+    public function getSearchQueryText()
+    {
+        return __("Search results for: '%1'", $this->escapeHtml($this->getQueryText()));
     }
 
     /**


### PR DESCRIPTION
Good morning,

This addon has for purpose to have a proper title and breadcrumbs for result page.

Before modification
![capture d ecran 2019-03-08 a 14 47 01](https://user-images.githubusercontent.com/2975845/54032159-1b077080-41b1-11e9-928d-d0089f40f02a.png)

After
![capture d ecran 2019-03-08 a 14 46 28](https://user-images.githubusercontent.com/2975845/54032146-13e06280-41b1-11e9-8fa1-11e29a8a93cb.png)

Not sure if you want to escape properly in outter function the query text.

Ilan PARMENTIER