### PR TITLE
Import Magento\Framework\DB\Select class

### DIFF
--- a/Model/ResourceModel/Page/Fulltext/Collection.php
+++ b/Model/ResourceModel/Page/Fulltext/Collection.php
@@ -15,6 +15,7 @@ namespace Smile\ElasticsuiteCms\Model\ResourceModel\Page\Fulltext;
 
 use Smile\ElasticsuiteCore\Search\RequestInterface;
 use Smile\ElasticsuiteCore\Search\Request\BucketInterface;
+use Magento\Framework\DB\Select;
 
 /**
  * Search engine product collection.


### PR DESCRIPTION
This class is used in `Model\ResourceModel\Page\Fulltext\Collection::setOrder`

Error

`Class 'Smile\ElasticsuiteCms\Model\ResourceModel\Page\Fulltext\Select'
not found in vendor/magento/framework/Code/Generator/EntityAbstract.php`