### PR TITLE
Made suggestions more in line with search results

### DIFF
--- a/Model/Autocomplete/Page/DataProvider.php
+++ b/Model/Autocomplete/Page/DataProvider.php
@@ -159,17 +159,12 @@ class DataProvider implements DataProviderInterface
      */
     private function getCmsPageCollection()
     {
-        $pageCollection = null;
-        $suggestedTerms = $this->getSuggestedTerms();
-        $terms          = [$this->queryFactory->get()->getQueryText()];
-
-        if (!empty($suggestedTerms)) {
-            $terms = array_merge($terms, $suggestedTerms);
-        }
-
         $pageCollection = $this->cmsCollectionFactory->create();
-        $pageCollection->addSearchFilter($terms);
+        
         $pageCollection->setPageSize($this->getResultsPageSize());
+        
+        $queryText = $this->queryFactory->get()->getQueryText();
+        $pageCollection->addSearchFilter($queryText);
 
         return $pageCollection;
     }


### PR DESCRIPTION
Retrieving suggested terms and adding them to the query results in less suggestions, which is unwanted. So I've made the querybuilding of the dataprovider more as in `Smile\ElasticsuiteCms\Block\Page\Suggest`

https://github.com/Smile-SA/magento2-module-elasticsuite-cms-search/blob/36ac046fce5764fd7e6c6ce6144ae28f1fa6bb96/Block/Page/Suggest.php#L173-L183