### PR TITLE
Support smile/elasticsuite 2.12.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "magento/module-store": ">=101.1.6",
         "magento/module-backend": ">=102.0.6",
         "magento/module-catalog": ">=104.0.6",
-        "magento/module-catalog-search": ">=102.0.6",	    
+        "magento/module-catalog-search": ">=102.0.6",
         "magento/magento-composer-installer": "*",
-        "smile/elasticsuite": "~2.11.0"
+        "smile/elasticsuite": "~2.12.0"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "^1.0.4"


### PR DESCRIPTION
So we can use this module on Magento 2.4.9

A new branch `2.12.x` should be created for this I believe

@rbayet, @romainruaud: can you guys take a look at if these changes are enough or if more changes are needed for compatibility with `smile/elasticsuite` 2.12.x? 

Many thanks!